### PR TITLE
Refactor: refactor auth forms to email-only login and simplify account inputs

### DIFF
--- a/src/features/auth/hooks/useAuth.js
+++ b/src/features/auth/hooks/useAuth.js
@@ -1,5 +1,5 @@
 import { useContext } from "react";
-import { AuthContext } from "@/app/providers/AuthContext";
+import { AuthContext } from "@/app/providers/AuthContext.jsx";
 
 export const useAuth = () => {
 	return useContext(AuthContext);

--- a/src/features/profile/components/ProfileForm.jsx
+++ b/src/features/profile/components/ProfileForm.jsx
@@ -73,7 +73,6 @@ export default function ProfileForm({ user, onSave, isLoading }) {
 	return (
 		<form onSubmit={handleSubmit} className="flex flex-col gap-6 w-full max-w-lg">
 			<div className="flex flex-col gap-2">
-				<label className="text-lg font-bold text-(--col-text-main)">{user.login}</label>
 				<label className="text-sm font-bold text-(--col-text-muted)">Nickname</label>
 				<div className="w-full flex flex-row items-center gap-4">
 					<Input

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -4,10 +4,11 @@ import { useAuth } from "@/features/auth/hooks/useAuth.js";
 import { GoogleLogin } from "@react-oauth/google";
 import { loginUser, loginWithGoogle } from "@/features/auth/api/auth.api.js";
 import Container from "@/shared/ui/Container.jsx";
+import Input from "@/shared/ui/Input.jsx";
 
 export default function Login() {
 	const [formData, setFormData] = useState({
-		login: "",
+		email: "",
 		password: "",
 	});
 
@@ -29,7 +30,7 @@ export default function Login() {
 
 		try {
 			const data = await loginUser({
-				login: formData.login,
+				email: formData.email,
 				password: formData.password,
 			});
 			login(data.user, data.token);
@@ -76,14 +77,13 @@ export default function Login() {
 					<form onSubmit={handleSubmit} className="w-full max-w-xs flex flex-col gap-5">
 						<div className="flex flex-col gap-2">
 							<label className="text-sm font-semibold text-(--col-text-muted) ml-1">
-								Login
+								Email
 							</label>
-							<input
-								className="input w-full text-lg py-3 px-4"
-								type="text"
-								name="login"
-								placeholder="Your login"
-								value={formData.login}
+							<Input
+								type="email"
+								name="email"
+								placeholder="Your email"
+								value={formData.email}
 								onChange={handleChange}
 								required
 								disabled={isLoading}
@@ -94,11 +94,10 @@ export default function Login() {
 							<label className="text-sm font-semibold text-(--col-text-muted) ml-1">
 								Password
 							</label>
-							<input
-								className="input w-full text-lg py-3 px-4"
+							<Input
 								type="password"
 								name="password"
-								placeholder="••••••••"
+								placeholder="Your password"
 								value={formData.password}
 								onChange={handleChange}
 								required

--- a/src/pages/Register.jsx
+++ b/src/pages/Register.jsx
@@ -24,7 +24,6 @@ export default function Register() {
 	const [formData, setFormData] = useState({
 		email: "",
 		code: "",
-		login: "",
 		password: "",
 		confirmPassword: "",
 		avatarUrl: "",
@@ -60,7 +59,6 @@ export default function Register() {
 			setFormData((prev) => ({
 				...prev,
 				email: googleData.email,
-				login: "",
 				avatarUrl: googleData.picture,
 				googleToken: credentialResponse.credential,
 			}));
@@ -87,17 +85,11 @@ export default function Register() {
 		if (formData.password !== formData.confirmPassword) {
 			return setError("Passwords do not match");
 		}
-		if (formData.login.length < QUIZ_CONSTRAINTS.LOGIN_MIN_LENGTH) {
-			return setError(
-				`Login must be at least ${QUIZ_CONSTRAINTS.LOGIN_MIN_LENGTH} characters`,
-			);
-		}
 
 		setIsLoading(true);
 		try {
 			const data = await registerUser({
 				email: formData.email,
-				login: formData.login,
 				password: formData.password,
 				code: formData.googleToken ? null : formData.code,
 				googleToken: formData.googleToken,
@@ -251,28 +243,11 @@ export default function Register() {
 
 					<div className="flex flex-col gap-1">
 						<label className="text-sm font-semibold text-(--col-text-muted)">
-							Login
-						</label>
-						<Input
-							type="text"
-							name="login"
-							placeholder="CoolUser123"
-							value={formData.login}
-							onChange={handleChange}
-							required
-							minLength={QUIZ_CONSTRAINTS.LOGIN_MIN_LENGTH}
-							className="text-lg"
-						/>
-					</div>
-
-					<div className="flex flex-col gap-1">
-						<label className="text-sm font-semibold text-(--col-text-muted)">
-							Password
+							Set your password
 						</label>
 						<Input
 							type="password"
 							name="password"
-							placeholder="••••••••"
 							value={formData.password}
 							onChange={handleChange}
 							required
@@ -283,12 +258,11 @@ export default function Register() {
 
 					<div className="flex flex-col gap-1">
 						<label className="text-sm font-semibold text-(--col-text-muted)">
-							Confirm Password
+							Confirm your password
 						</label>
 						<Input
 							type="password"
 							name="confirmPassword"
-							placeholder="••••••••"
 							value={formData.confirmPassword}
 							onChange={handleChange}
 							required

--- a/src/pages/Register.jsx
+++ b/src/pages/Register.jsx
@@ -234,7 +234,7 @@ export default function Register() {
 					className="w-full flex flex-col gap-4 animate-fade-in"
 				>
 					<div className="p-3 mb-2 bg-(--col-bg-input-darker) rounded-lg border border-(--col-border) flex items-center gap-3">
-						<Avatar src={formData.avatarUrl} name={formData.login} size="md" />
+						<Avatar src={formData.avatarUrl} size="md" />
 						<div className="flex flex-col overflow-hidden">
 							<span className="text-xs text-(--col-text-muted)">Registering as</span>
 							<span className="text-sm font-bold truncate">{formData.email}</span>

--- a/src/shared/config/config.js
+++ b/src/shared/config/config.js
@@ -27,7 +27,7 @@ export const SORT_OPTIONS = [
 	{ id: "newest", label: "Newest first" },
 	{ id: "oldest", label: "Oldest first" },
 	{ id: "az", label: "Alphabetical (A-Z)" },
-	{ id: "za", label: "Alphabetical (sZ-A)" },
+	{ id: "za", label: "Alphabetical (Z-A)" },
 ];
 
 // const API_URL = "http://localhost:3000/api";

--- a/src/shared/config/config.js
+++ b/src/shared/config/config.js
@@ -27,11 +27,13 @@ export const SORT_OPTIONS = [
 	{ id: "newest", label: "Newest first" },
 	{ id: "oldest", label: "Oldest first" },
 	{ id: "az", label: "Alphabetical (A-Z)" },
-	{ id: "za", label: "Alphabetical (Z-A)" },
+	{ id: "za", label: "Alphabetical (sZ-A)" },
 ];
 
+// const API_URL = "http://localhost:3000/api";
+const API_URL = import.meta.env.VITE_API_URL;
+
 export const URL_CONFIG = {
-	// API_URL: "http://localhost:3000/api",
-	API_URL: import.meta.env.VITE_API_URL,
-	AUTH_URL: import.meta.env.VITE_API_URL.replace("/api", "/auth"),
+	API_URL: API_URL,
+	AUTH_URL: API_URL.replace("/api", "/auth"),
 };

--- a/src/shared/ui/Input.jsx
+++ b/src/shared/ui/Input.jsx
@@ -1,8 +1,8 @@
-export default function Input({ placeholder, className = "", ...props }) {
+export default function Input({ type = "text", placeholder, className = "", ...props }) {
 	return (
 		<>
 			<input
-				type="text"
+				type={type}
 				placeholder={placeholder}
 				className={`${className} input`}
 				{...props}


### PR DESCRIPTION
## Summary
This PR removes username/login usage from the authentication UI flow and standardizes forms around email + password. It also improves input reuse by making the shared Input component accept dynamic input types, and tightens API URL configuration.

## What Changed
- Updated login flow to use `email` instead of `login` in form state and API payload.
- Replaced native inputs in Login with the shared `Input` component for consistency.
- Removed login field and related validation from Register.
- Simplified profile form by removing the extra login label display.
- Extended shared `Input` component to accept a configurable `type` prop (defaults to `text`).
- Fixed `useAuth` context import path to include `.jsx`.
- Refactored API config to derive `AUTH_URL` from a single `API_URL` constant.

## Why
- Aligns UX and payloads with email-first authentication.
- Reduces form complexity and duplicated input markup.
- Improves consistency across pages by using shared UI components.
- Makes config handling cleaner and less error-prone.

## Validation
- `npm run lint` passed
- `npm run build` passed

## Impact / Notes
- Frontend login/register payload expectations now center on `email` and `password` rather than `login`.
- No route-level behavior changes; this is primarily a form/data-shape refactor with small config and import fixes.

## Suggested Reviewer Checklist
1. Verify login works with email/password.
2. Verify register works without a login/username field.
3. Verify Google register path still succeeds and prefilled fields behave correctly.
4. Confirm profile edit UI still renders and saves as expected.
5. Confirm auth-related API URLs resolve correctly in each environment.