### PR TITLE
Refactor: refactor Zustand stores to grouped selectors and action-only hooks

### DIFF
--- a/src/app/AppRoutes.jsx
+++ b/src/app/AppRoutes.jsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from "react";
 import { Routes, Route } from "react-router-dom";
 
 import useAutoReload from "@/shared/hooks/useAutoReload.js";
-import { useAuth } from "@/features/auth/hooks/useAuth.js";
+import { useAuthActions, useAuthSessionState } from "@/features/auth/hooks/useAuth.js";
 
 import Quizzes from "@/pages/Quizzes.jsx";
 import Results from "@/pages/Results.jsx";
@@ -17,8 +17,8 @@ import NotFound from "@/pages/NotFound.jsx";
 import PublicProfile from "@/pages/PublicProfile.jsx";
 
 export default function AppRoutes() {
-	const token = useAuth((state) => state.token);
-	const checkSession = useAuth((state) => state.checkSession);
+	const { token } = useAuthSessionState();
+	const { checkSession } = useAuthActions();
 
 	const [refreshKey, setRefreshKey] = useState(0);
 

--- a/src/features/auth/hooks/useAuth.js
+++ b/src/features/auth/hooks/useAuth.js
@@ -1,5 +1,9 @@
-import { useAuthStore } from "@/features/auth/stores/authStore.js";
+import {
+	useAuthActions,
+	useAuthSessionState,
+	useAuthUserState,
+} from "@/features/auth/stores/authStore.js";
 
-export const useAuth = (selector = (state) => state) => {
-	return useAuthStore(selector);
-};
+export { useAuthUserState };
+export { useAuthSessionState };
+export { useAuthActions };

--- a/src/features/auth/stores/authStore.js
+++ b/src/features/auth/stores/authStore.js
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { useShallow } from "zustand/react/shallow";
 import { verifySession } from "@/features/profile/api/user.api.js";
 import { isTokenExpired } from "@/shared/libs/jwt.js";
 
@@ -35,70 +36,88 @@ export const useAuthStore = create((set, get) => ({
 	user: getStoredUser(),
 	token: getStoredToken(),
 	isSessionChecking: false,
+	actions: {
+		login: (userData, authToken) => {
+			persistAuth(userData, authToken);
+			sessionCheckedToken = authToken;
+			set({ user: userData, token: authToken });
+		},
 
-	login: (userData, authToken) => {
-		persistAuth(userData, authToken);
-		sessionCheckedToken = authToken;
-		set({ user: userData, token: authToken });
-	},
+		logout: () => {
+			sessionCheckPromise = null;
+			sessionCheckedToken = null;
+			persistAuth(null, null);
+			set({ user: null, token: null, isSessionChecking: false });
+		},
 
-	logout: () => {
-		sessionCheckPromise = null;
-		sessionCheckedToken = null;
-		persistAuth(null, null);
-		set({ user: null, token: null, isSessionChecking: false });
-	},
+		checkSession: async ({ force = false } = {}) => {
+			const { token, actions } = get();
 
-	checkSession: async ({ force = false } = {}) => {
-		const { token, logout } = get();
-
-		if (!token) return false;
-		if (isTokenExpired(token)) {
-			logout();
-			return false;
-		}
-
-		if (!force && sessionCheckedToken === token) return true;
-
-		if (sessionCheckPromise) return sessionCheckPromise;
-
-		set({ isSessionChecking: true });
-		const requestToken = token;
-
-		const currentPromise = verifySession()
-			.then((data) => {
-				if (get().token !== requestToken) {
-					return false;
-				}
-
-				if (data?.user) {
-					persistAuth(data.user, requestToken);
-					set({ user: data.user });
-				}
-				sessionCheckedToken = requestToken;
-				return true;
-			})
-			.catch(() => {
-				if (get().token !== requestToken) {
-					return false;
-				}
-
-				logout();
+			if (!token) return false;
+			if (isTokenExpired(token)) {
+				actions.logout();
 				return false;
-			})
-			.finally(() => {
-				if (sessionCheckPromise === currentPromise) {
-					sessionCheckPromise = null;
-				}
+			}
 
-				if (get().token === requestToken) {
-					set({ isSessionChecking: false });
-				}
-			});
+			if (!force && sessionCheckedToken === token) return true;
 
-		sessionCheckPromise = currentPromise;
-		return currentPromise;
+			if (sessionCheckPromise) return sessionCheckPromise;
+
+			set({ isSessionChecking: true });
+			const requestToken = token;
+
+			const currentPromise = verifySession()
+				.then((data) => {
+					if (get().token !== requestToken) {
+						return false;
+					}
+
+					if (data?.user) {
+						persistAuth(data.user, requestToken);
+						set({ user: data.user });
+					}
+					sessionCheckedToken = requestToken;
+					return true;
+				})
+				.catch(() => {
+					if (get().token !== requestToken) {
+						return false;
+					}
+
+					actions.logout();
+					return false;
+				})
+				.finally(() => {
+					if (sessionCheckPromise === currentPromise) {
+						sessionCheckPromise = null;
+					}
+
+					if (get().token === requestToken) {
+						set({ isSessionChecking: false });
+					}
+				});
+
+			sessionCheckPromise = currentPromise;
+			return currentPromise;
+		},
 	},
 }));
+
+export const useAuthUserState = () =>
+	useAuthStore(
+		useShallow((state) => ({
+			user: state.user,
+		})),
+	);
+
+export const useAuthSessionState = () =>
+	useAuthStore(
+		useShallow((state) => ({
+			token: state.token,
+			isSessionChecking: state.isSessionChecking,
+		})),
+	);
+
+export const useAuthActions = () => useAuthStore.getState().actions;
 
 export default useAuthStore;

--- a/src/features/profile/components/ModalChangePassword.jsx
+++ b/src/features/profile/components/ModalChangePassword.jsx
@@ -3,7 +3,7 @@ import Modal from "@/shared/ui/Modal.jsx";
 import Input from "@/shared/ui/Input.jsx";
 import Button from "@/shared/ui/Button.jsx";
 import { changePassword } from "@/features/profile/api/user.api.js";
-import { useToastStore } from "@/shared/ui/toast/toastStore.js";
+import { useToastActions } from "@/shared/ui/toast/toastStore.js";
 
 export default function ModalChangePassword({ isOpen, onClose }) {
 	const [currentPassword, setCurrentPassword] = useState("");
@@ -13,7 +13,7 @@ export default function ModalChangePassword({ isOpen, onClose }) {
 	const [isLoading, setIsLoading] = useState(false);
 	const [error, setError] = useState("");
 
-	const addToast = useToastStore((state) => state.addToast);
+	const { addToast } = useToastActions();
 
 	const handleClose = () => {
 		setCurrentPassword("");

--- a/src/features/profile/components/ProfileForm.jsx
+++ b/src/features/profile/components/ProfileForm.jsx
@@ -1,20 +1,20 @@
 import { useState } from "react";
 import { GoogleLogin } from "@react-oauth/google";
 import { linkGoogleAccount } from "@/features/auth/api/auth.api.js";
-import { useAuth } from "@/features/auth/hooks/useAuth.js";
+import { useAuthActions, useAuthSessionState } from "@/features/auth/hooks/useAuth.js";
 import Input from "@/shared/ui/Input.jsx";
 import Button from "@/shared/ui/Button.jsx";
 import ColorGenerator from "./ColorGenerator.jsx";
 import Avatar from "@/shared/ui/Avatar.jsx";
 import { getNicknameArray } from "../api/user.api.js";
 import { QUIZ_CONSTRAINTS } from "@/shared/config/config.js";
-import { useToastStore } from "@/shared/ui/toast/toastStore.js";
+import { useToastActions } from "@/shared/ui/toast/toastStore.js";
 
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
 export default function ProfileForm({ user, onSave, isLoading }) {
-	const login = useAuth((state) => state.login);
-	const token = useAuth((state) => state.token);
+	const { login } = useAuthActions();
+	const { token } = useAuthSessionState();
 
 	const [hasGoogleAccount, setHasGoogleAccount] = useState(!!user.googleId);
 	const [linkError, setLinkError] = useState(null);
@@ -26,7 +26,7 @@ export default function ProfileForm({ user, onSave, isLoading }) {
 
 	const [generatedColor, setGeneratedColor] = useState(user.themeColor || "#4f46e5");
 
-	const addToast = useToastStore((state) => state.addToast);
+	const { addToast } = useToastActions();
 
 	const hasChanges =
 		nickname !== user.nickname ||

--- a/src/features/profile/hooks/useProfilePageActions.js
+++ b/src/features/profile/hooks/useProfilePageActions.js
@@ -1,6 +1,6 @@
 import { useEffect, useCallback } from "react";
 import { updateUser, deleteUser } from "@/features/profile/api/user.api.js";
-import { useProfilePageStore } from "@/features/profile/stores/profilePageStore.js";
+import { useProfilePageActions as useProfilePageStoreActions } from "@/features/profile/stores/profilePageStore.js";
 
 export function useProfilePageActions({
 	navigate,
@@ -11,10 +11,7 @@ export function useProfilePageActions({
 	isSessionChecking,
 	addToast,
 }) {
-	const setUser = useProfilePageStore((state) => state.setUser);
-	const setIsLoading = useProfilePageStore((state) => state.setIsLoading);
-	const setIsSaving = useProfilePageStore((state) => state.setIsSaving);
-	const closeDeleteModal = useProfilePageStore((state) => state.closeDeleteModal);
+	const { setUser, setIsLoading, setIsSaving, closeDeleteModal } = useProfilePageStoreActions();
 
 	useEffect(() => {
 		if (!token) {

--- a/src/features/profile/stores/profilePageStore.js
+++ b/src/features/profile/stores/profilePageStore.js
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { useShallow } from "zustand/react/shallow";
 
 const initialState = {
 	user: null,
@@ -10,18 +11,44 @@ const initialState = {
 
 export const useProfilePageStore = create((set) => ({
 	...initialState,
+	actions: {
+		setUser: (user) => set({ user }),
+		setIsLoading: (isLoading) => set({ isLoading }),
+		setIsSaving: (isSaving) => set({ isSaving }),
 
-	setUser: (user) => set({ user }),
-	setIsLoading: (isLoading) => set({ isLoading }),
-	setIsSaving: (isSaving) => set({ isSaving }),
+		openDeleteModal: () => set({ isDeleteModalOpen: true }),
+		closeDeleteModal: () => set({ isDeleteModalOpen: false }),
 
-	openDeleteModal: () => set({ isDeleteModalOpen: true }),
-	closeDeleteModal: () => set({ isDeleteModalOpen: false }),
+		openPasswordModal: () => set({ isPasswordModalOpen: true }),
+		closePasswordModal: () => set({ isPasswordModalOpen: false }),
 
-	openPasswordModal: () => set({ isPasswordModalOpen: true }),
-	closePasswordModal: () => set({ isPasswordModalOpen: false }),
-
-	resetProfilePage: () => set({ ...initialState }),
+		resetProfilePage: () => set({ ...initialState }),
+	},
 }));
+
+export const useProfilePageIdentityState = () =>
+	useProfilePageStore(
+		useShallow((state) => ({
+			user: state.user,
+		})),
+	);
+
+export const useProfilePageStatusState = () =>
+	useProfilePageStore(
+		useShallow((state) => ({
+			isLoading: state.isLoading,
+			isSaving: state.isSaving,
+		})),
+	);
+
+export const useProfilePageModalState = () =>
+	useProfilePageStore(
+		useShallow((state) => ({
+			isDeleteModalOpen: state.isDeleteModalOpen,
+			isPasswordModalOpen: state.isPasswordModalOpen,
+		})),
+	);
+
+export const useProfilePageActions = () => useProfilePageStore.getState().actions;
 
 export default useProfilePageStore;

--- a/src/features/quizzes/components/edit/OptionEditor.jsx
+++ b/src/features/quizzes/components/edit/OptionEditor.jsx
@@ -1,21 +1,14 @@
 import Input from "@/shared/ui/Input.jsx";
 import Radio from "@/shared/ui/Radio.jsx";
 import Button from "@/shared/ui/Button.jsx";
-import { useQuizEditorStore } from "@/features/quizzes/stores/quizEditorStore.js";
-
-const EMPTY_ERRORS = {};
+import {
+	useQuizEditorActions,
+	useQuizEditorOptionState,
+} from "@/features/quizzes/stores/quizEditorStore.js";
 
 export default function Option({ questionId, optionId }) {
-	const option = useQuizEditorStore((state) => {
-		const question = state.questions.find((item) => item.id === questionId);
-		return question?.options.find((item) => item.id === optionId);
-	});
-	const errors = useQuizEditorStore(
-		(state) => state.errors.questions?.[questionId]?.options?.[optionId] || EMPTY_ERRORS,
-	);
-	const deleteOption = useQuizEditorStore((state) => state.deleteOption);
-	const updateOptionText = useQuizEditorStore((state) => state.updateOptionText);
-	const setCorrectOption = useQuizEditorStore((state) => state.setCorrectOption);
+	const { option, errors } = useQuizEditorOptionState(questionId, optionId);
+	const { deleteOption, updateOptionText, setCorrectOption } = useQuizEditorActions();
 
 	if (!option) {
 		return null;

--- a/src/features/quizzes/components/edit/QuestionEditor.jsx
+++ b/src/features/quizzes/components/edit/QuestionEditor.jsx
@@ -1,20 +1,14 @@
 import Option from "./OptionEditor.jsx";
 import Input from "@/shared/ui/Input.jsx";
 import Button from "@/shared/ui/Button.jsx";
-import { useQuizEditorStore } from "@/features/quizzes/stores/quizEditorStore.js";
-
-const EMPTY_ERRORS = {};
+import {
+	useQuizEditorActions,
+	useQuizEditorQuestionState,
+} from "@/features/quizzes/stores/quizEditorStore.js";
 
 export default function Question({ questionId, index }) {
-	const question = useQuizEditorStore((state) =>
-		state.questions.find((item) => item.id === questionId),
-	);
-	const errors = useQuizEditorStore(
-		(state) => state.errors.questions?.[questionId] || EMPTY_ERRORS,
-	);
-	const deleteQuestion = useQuizEditorStore((state) => state.deleteQuestion);
-	const updateQuestionText = useQuizEditorStore((state) => state.updateQuestionText);
-	const addOption = useQuizEditorStore((state) => state.addOption);
+	const { question, errors } = useQuizEditorQuestionState(questionId);
+	const { deleteQuestion, updateQuestionText, addOption } = useQuizEditorActions();
 
 	if (!question) {
 		return null;

--- a/src/features/quizzes/components/modals/ModalDescription.jsx
+++ b/src/features/quizzes/components/modals/ModalDescription.jsx
@@ -2,13 +2,13 @@ import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { deleteQuiz, clearAllQuizzesCache } from "@/features/quizzes/api/quizzes.api.js";
 import Button from "@/shared/ui/Button.jsx";
-import { useAuth } from "@/features/auth/hooks/useAuth.js";
+import { useAuthUserState } from "@/features/auth/hooks/useAuth.js";
 import Modal from "@/shared/ui/Modal.jsx";
 import ModalConfirm from "@/shared/ui/ModalConfirm.jsx";
 import Avatar from "@/shared/ui/Avatar.jsx";
 
 export default function ModalDescription({ quiz, onClose, isOpen, onDeleteSuccess }) {
-	const user = useAuth((state) => state.user);
+	const { user } = useAuthUserState();
 	const quizId = quiz?.id || quiz?._id;
 
 	const navigate = useNavigate();

--- a/src/features/quizzes/components/quiz/Option.jsx
+++ b/src/features/quizzes/components/quiz/Option.jsx
@@ -1,18 +1,17 @@
 import Radio from "@/shared/ui/Radio.jsx";
-import { useQuizSessionStore } from "@/features/quizzes/stores/quizSessionStore.js";
+import {
+	useQuizSessionActions,
+	useQuizSessionOptionState,
+} from "@/features/quizzes/stores/quizSessionStore.js";
 
 const EMPTY_SELECTED = [];
 
 export default function Option({ questionId, optionId, questionIndex, disabled }) {
-	const question = useQuizSessionStore((state) =>
-		state.quizData?.questions?.find((item) => item.id === questionId),
+	const { question, mode, answers, resultAnswers } = useQuizSessionOptionState(
+		questionId,
+		questionIndex,
 	);
-	const mode = useQuizSessionStore((state) => state.mode);
-	const answers = useQuizSessionStore((state) => state.answers);
-	const resultAnswers = useQuizSessionStore(
-		(state) => state.resultData?.answers || EMPTY_SELECTED,
-	);
-	const selectAnswer = useQuizSessionStore((state) => state.selectAnswer);
+	const { selectAnswer } = useQuizSessionActions();
 
 	if (!question) {
 		return null;

--- a/src/features/quizzes/components/quiz/Question.jsx
+++ b/src/features/quizzes/components/quiz/Question.jsx
@@ -1,12 +1,8 @@
 import Option from "./Option.jsx";
-import { useQuizSessionStore } from "@/features/quizzes/stores/quizSessionStore.js";
+import { useQuizSessionQuestionState } from "@/features/quizzes/stores/quizSessionStore.js";
 
 export default function Question({ questionId, index }) {
-	const question = useQuizSessionStore((state) =>
-		state.quizData?.questions?.find((item) => item.id === questionId),
-	);
-	const hasError = useQuizSessionStore((state) => Boolean(state.errors[index]));
-	const mode = useQuizSessionStore((state) => state.mode);
+	const { question, hasError, mode } = useQuizSessionQuestionState(questionId, index);
 
 	if (!question) {
 		return null;

--- a/src/features/quizzes/hooks/useQuizEditorValidation.js
+++ b/src/features/quizzes/hooks/useQuizEditorValidation.js
@@ -1,10 +1,11 @@
 import { useCallback } from "react";
-import { useQuizEditorStore } from "@/features/quizzes/stores/quizEditorStore.js";
+import {
+	useQuizEditorActions,
+	useQuizEditorStore,
+} from "@/features/quizzes/stores/quizEditorStore.js";
 
 export function useQuizEditorValidation() {
-	const setErrors = useQuizEditorStore((state) => state.setErrors);
-	const setAlertInfo = useQuizEditorStore((state) => state.setAlertInfo);
-	const closeAlert = useQuizEditorStore((state) => state.closeAlert);
+	const { setErrors, setAlertInfo, closeAlert } = useQuizEditorActions();
 
 	const validate = useCallback(() => {
 		const { title, description, questions } = useQuizEditorStore.getState();

--- a/src/features/quizzes/stores/quizEditorStore.js
+++ b/src/features/quizzes/stores/quizEditorStore.js
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { useShallow } from "zustand/react/shallow";
 
 const DEFAULT_QUESTION = {
 	id: 0,
@@ -25,113 +26,161 @@ const initialState = {
 	alertInfo: { isOpen: false, message: "" },
 };
 
+const EMPTY_OBJECT = {};
+
 export const useQuizEditorStore = create((set) => ({
 	...initialState,
+	actions: {
+		initEditor: (isManagePage) => set({ loading: Boolean(isManagePage) }),
 
-	initEditor: (isManagePage) => set({ loading: Boolean(isManagePage) }),
+		setTitle: (title) =>
+			set({
+				title,
+				counter: title.length,
+			}),
 
-	setTitle: (title) =>
-		set({
-			title,
-			counter: title.length,
-		}),
+		clearTitle: () => set({ title: "", counter: 0 }),
 
-	clearTitle: () => set({ title: "", counter: 0 }),
+		setDescription: (description) => set({ description }),
 
-	setDescription: (description) => set({ description }),
+		setErrors: (errors) => set({ errors }),
 
-	setErrors: (errors) => set({ errors }),
+		setAlertInfo: (alertInfo) => set({ alertInfo }),
 
-	setAlertInfo: (alertInfo) => set({ alertInfo }),
+		closeAlert: () => set({ alertInfo: { isOpen: false, message: "" } }),
 
-	closeAlert: () => set({ alertInfo: { isOpen: false, message: "" } }),
+		loadQuiz: (quiz) =>
+			set({
+				title: quiz.title,
+				description: quiz.description,
+				questions: quiz.questions,
+				counter: quiz.title.length,
+				loading: false,
+			}),
 
-	loadQuiz: (quiz) =>
-		set({
-			title: quiz.title,
-			description: quiz.description,
-			questions: quiz.questions,
-			counter: quiz.title.length,
-			loading: false,
-		}),
+		addQuestion: () =>
+			set((state) => {
+				const newId =
+					state.questions.length > 0
+						? Math.max(...state.questions.map((q) => q.id)) + 1
+						: 0;
+				return {
+					questions: [...state.questions, { ...DEFAULT_QUESTION, id: newId }],
+				};
+			}),
 
-	addQuestion: () =>
-		set((state) => {
-			const newId =
-				state.questions.length > 0 ? Math.max(...state.questions.map((q) => q.id)) + 1 : 0;
+		deleteQuestion: (questionId) =>
+			set((state) => ({
+				questions: state.questions.filter((question) => question.id !== questionId),
+			})),
+
+		updateQuestionText: (questionId, text) =>
+			set((state) => ({
+				questions: state.questions.map((question) =>
+					question.id === questionId ? { ...question, text } : question,
+				),
+			})),
+
+		addOption: (questionId) =>
+			set((state) => ({
+				questions: state.questions.map((question) => {
+					if (question.id !== questionId) return question;
+
+					const newOptionId =
+						question.options.length > 0
+							? Math.max(...question.options.map((option) => option.id)) + 1
+							: 0;
+
+					return {
+						...question,
+						options: [
+							...question.options,
+							{ id: newOptionId, text: "", isCorrect: false },
+						],
+					};
+				}),
+			})),
+
+		deleteOption: (questionId, optionId) =>
+			set((state) => ({
+				questions: state.questions.map((question) => {
+					if (question.id !== questionId) return question;
+					return {
+						...question,
+						options: question.options.filter((option) => option.id !== optionId),
+					};
+				}),
+			})),
+
+		updateOptionText: (questionId, optionId, text) =>
+			set((state) => ({
+				questions: state.questions.map((question) => {
+					if (question.id !== questionId) return question;
+					return {
+						...question,
+						options: question.options.map((option) =>
+							option.id === optionId ? { ...option, text } : option,
+						),
+					};
+				}),
+			})),
+
+		setCorrectOption: (questionId, optionId) =>
+			set((state) => ({
+				questions: state.questions.map((question) => {
+					if (question.id !== questionId) return question;
+					return {
+						...question,
+						options: question.options.map((option) => ({
+							...option,
+							isCorrect: option.id === optionId,
+						})),
+					};
+				}),
+			})),
+
+		resetEditor: () => set({ ...initialState }),
+	},
+}));
+
+export const useQuizEditorMetaState = () =>
+	useQuizEditorStore(
+		useShallow((state) => ({
+			loading: state.loading,
+			alertInfo: state.alertInfo,
+		})),
+	);
+
+export const useQuizEditorContentState = () =>
+	useQuizEditorStore(
+		useShallow((state) => ({
+			title: state.title,
+			description: state.description,
+			counter: state.counter,
+			errors: state.errors,
+			questions: state.questions,
+		})),
+	);
+
+export const useQuizEditorQuestionState = (questionId) =>
+	useQuizEditorStore(
+		useShallow((state) => ({
+			question: state.questions.find((item) => item.id === questionId),
+			errors: state.errors.questions?.[questionId] || EMPTY_OBJECT,
+		})),
+	);
+
+export const useQuizEditorOptionState = (questionId, optionId) =>
+	useQuizEditorStore(
+		useShallow((state) => {
+			const question = state.questions.find((item) => item.id === questionId);
 			return {
-				questions: [...state.questions, { ...DEFAULT_QUESTION, id: newId }],
+				option: question?.options.find((item) => item.id === optionId),
+				errors: state.errors.questions?.[questionId]?.options?.[optionId] || EMPTY_OBJECT,
 			};
 		}),
+	);
 
-	deleteQuestion: (questionId) =>
-		set((state) => ({
-			questions: state.questions.filter((question) => question.id !== questionId),
-		})),
-
-	updateQuestionText: (questionId, text) =>
-		set((state) => ({
-			questions: state.questions.map((question) =>
-				question.id === questionId ? { ...question, text } : question,
-			),
-		})),
-
-	addOption: (questionId) =>
-		set((state) => ({
-			questions: state.questions.map((question) => {
-				if (question.id !== questionId) return question;
-
-				const newOptionId =
-					question.options.length > 0
-						? Math.max(...question.options.map((option) => option.id)) + 1
-						: 0;
-
-				return {
-					...question,
-					options: [...question.options, { id: newOptionId, text: "", isCorrect: false }],
-				};
-			}),
-		})),
-
-	deleteOption: (questionId, optionId) =>
-		set((state) => ({
-			questions: state.questions.map((question) => {
-				if (question.id !== questionId) return question;
-				return {
-					...question,
-					options: question.options.filter((option) => option.id !== optionId),
-				};
-			}),
-		})),
-
-	updateOptionText: (questionId, optionId, text) =>
-		set((state) => ({
-			questions: state.questions.map((question) => {
-				if (question.id !== questionId) return question;
-				return {
-					...question,
-					options: question.options.map((option) =>
-						option.id === optionId ? { ...option, text } : option,
-					),
-				};
-			}),
-		})),
-
-	setCorrectOption: (questionId, optionId) =>
-		set((state) => ({
-			questions: state.questions.map((question) => {
-				if (question.id !== questionId) return question;
-				return {
-					...question,
-					options: question.options.map((option) => ({
-						...option,
-						isCorrect: option.id === optionId,
-					})),
-				};
-			}),
-		})),
-
-	resetEditor: () => set({ ...initialState }),
-}));
+export const useQuizEditorActions = () => useQuizEditorStore.getState().actions;
 
 export default useQuizEditorStore;

--- a/src/features/quizzes/stores/quizSessionStore.js
+++ b/src/features/quizzes/stores/quizSessionStore.js
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { useShallow } from "zustand/react/shallow";
 
 const initialState = {
 	loading: true,
@@ -12,61 +13,97 @@ const initialState = {
 
 export const useQuizSessionStore = create((set) => ({
 	...initialState,
+	actions: {
+		resetSession: () => set({ ...initialState }),
 
-	resetSession: () => set({ ...initialState }),
+		setLoading: (loading) => set({ loading }),
 
-	setLoading: (loading) => set({ loading }),
+		loadQuizForPlay: (quiz) =>
+			set({
+				quizData: quiz,
+				resultData: null,
+				answers: [],
+				errors: {},
+				mode: "play",
+			}),
 
-	loadQuizForPlay: (quiz) =>
-		set({
-			quizData: quiz,
-			resultData: null,
-			answers: [],
-			errors: {},
-			mode: "play",
-		}),
+		loadResultForView: (result) =>
+			set({
+				resultData: result,
+				quizData: {
+					title: result.quizTitle,
+					questions: result.questions,
+				},
+				answers: result.answers || [],
+				errors: {},
+				mode: "result",
+			}),
 
-	loadResultForView: (result) =>
-		set({
-			resultData: result,
-			quizData: {
-				title: result.quizTitle,
-				questions: result.questions,
-			},
-			answers: result.answers || [],
-			errors: {},
-			mode: "result",
-		}),
+		selectAnswer: (questionIndex, optionId) =>
+			set((state) => {
+				const nextAnswers = [...state.answers];
+				nextAnswers[questionIndex] = [optionId];
 
-	selectAnswer: (questionIndex, optionId) =>
-		set((state) => {
-			const nextAnswers = [...state.answers];
-			nextAnswers[questionIndex] = [optionId];
+				if (!state.errors[questionIndex]) {
+					return { answers: nextAnswers };
+				}
 
-			if (!state.errors[questionIndex]) {
-				return { answers: nextAnswers };
-			}
+				const nextErrors = { ...state.errors };
+				delete nextErrors[questionIndex];
 
-			const nextErrors = { ...state.errors };
-			delete nextErrors[questionIndex];
+				return {
+					answers: nextAnswers,
+					errors: nextErrors,
+				};
+			}),
 
-			return {
-				answers: nextAnswers,
-				errors: nextErrors,
-			};
-		}),
+		setValidationErrors: (errors) => set({ errors }),
 
-	setValidationErrors: (errors) => set({ errors }),
+		setGuestResult: (result) =>
+			set({
+				resultData: result,
+				mode: "result",
+			}),
 
-	setGuestResult: (result) =>
-		set({
-			resultData: result,
-			mode: "result",
-		}),
+		setAlertInfo: (alertInfo) => set({ alertInfo }),
 
-	setAlertInfo: (alertInfo) => set({ alertInfo }),
-
-	closeAlert: () => set({ alertInfo: { isOpen: false, message: "" } }),
+		closeAlert: () => set({ alertInfo: { isOpen: false, message: "" } }),
+	},
 }));
+
+export const useQuizSessionViewState = () =>
+	useQuizSessionStore(
+		useShallow((state) => ({
+			loading: state.loading,
+			quizData: state.quizData,
+			resultData: state.resultData,
+			answers: state.answers,
+			errors: state.errors,
+			alertInfo: state.alertInfo,
+			mode: state.mode,
+		})),
+	);
+
+export const useQuizSessionQuestionState = (questionId, index) =>
+	useQuizSessionStore(
+		useShallow((state) => ({
+			question: state.quizData?.questions?.find((item) => item.id === questionId),
+			hasError: Boolean(state.errors[index]),
+			mode: state.mode,
+		})),
+	);
+
+export const useQuizSessionOptionState = (questionId, questionIndex) =>
+	useQuizSessionStore(
+		useShallow((state) => ({
+			question: state.quizData?.questions?.find((item) => item.id === questionId),
+			mode: state.mode,
+			answers: state.answers,
+			resultAnswers: state.resultData?.answers || [],
+			questionIndex,
+		})),
+	);
+
+export const useQuizSessionActions = () => useQuizSessionStore.getState().actions;
 
 export default useQuizSessionStore;

--- a/src/features/quizzes/stores/quizSessionStore.js
+++ b/src/features/quizzes/stores/quizSessionStore.js
@@ -1,6 +1,8 @@
 import { create } from "zustand";
 import { useShallow } from "zustand/react/shallow";
 
+const EMPTY_SELECTED = [];
+
 const initialState = {
 	loading: true,
 	quizData: null,
@@ -99,7 +101,7 @@ export const useQuizSessionOptionState = (questionId, questionIndex) =>
 			question: state.quizData?.questions?.find((item) => item.id === questionId),
 			mode: state.mode,
 			answers: state.answers,
-			resultAnswers: state.resultData?.answers || [],
+			resultAnswers: state.resultData?.answers ?? EMPTY_SELECTED,
 			questionIndex,
 		})),
 	);

--- a/src/pages/Edit.jsx
+++ b/src/pages/Edit.jsx
@@ -8,14 +8,18 @@ import {
 import { useEffect } from "react";
 import Question from "@/features/quizzes/components/edit/QuestionEditor.jsx";
 import useQuizEditorValidation from "@/features/quizzes/hooks/useQuizEditorValidation.js";
-import { useQuizEditorStore } from "@/features/quizzes/stores/quizEditorStore.js";
+import {
+	useQuizEditorContentState,
+	useQuizEditorMetaState,
+	useQuizEditorStore,
+} from "@/features/quizzes/stores/quizEditorStore.js";
 import Button from "@/shared/ui/Button.jsx";
 import Container from "@/shared/ui/Container.jsx";
 import Input from "@/shared/ui/Input.jsx";
 import ModalConfirm from "@/shared/ui/ModalConfirm.jsx";
 import Textarea from "@/shared/ui/Textarea.jsx";
 import { QUIZ_CONSTRAINTS } from "@/shared/config/config.js";
-import { useToastStore } from "@/shared/ui/toast/toastStore.js";
+import { useToastActions } from "@/shared/ui/toast/toastStore.js";
 
 export default function Edit() {
 	const navigate = useNavigate();
@@ -23,46 +27,33 @@ export default function Edit() {
 	const location = useLocation();
 
 	const isManagePage = location.pathname.startsWith("/manage");
-	const loading = useQuizEditorStore((state) => state.loading);
-	const alertInfo = useQuizEditorStore((state) => state.alertInfo);
-	const title = useQuizEditorStore((state) => state.title);
-	const description = useQuizEditorStore((state) => state.description);
-	const counter = useQuizEditorStore((state) => state.counter);
-	const errors = useQuizEditorStore((state) => state.errors);
-	const questions = useQuizEditorStore((state) => state.questions);
-	const initEditor = useQuizEditorStore((state) => state.initEditor);
-	const loadQuiz = useQuizEditorStore((state) => state.loadQuiz);
-	const resetEditor = useQuizEditorStore((state) => state.resetEditor);
-	const setTitle = useQuizEditorStore((state) => state.setTitle);
-	const clearTitle = useQuizEditorStore((state) => state.clearTitle);
-	const setDescription = useQuizEditorStore((state) => state.setDescription);
-	const addQuestion = useQuizEditorStore((state) => state.addQuestion);
+	const { loading, alertInfo } = useQuizEditorMetaState();
+	const { title, description, counter, errors, questions } = useQuizEditorContentState();
+	const editorActions = useQuizEditorStore.getState().actions;
 	const { validate, showSaveError, closeAlert } = useQuizEditorValidation();
-	const addToast = useToastStore((state) => state.addToast);
+	const { addToast } = useToastActions();
 
 	useEffect(() => {
-		resetEditor();
-		initEditor(isManagePage);
-	}, [isManagePage, initEditor, resetEditor]);
+		editorActions.resetEditor();
+		editorActions.initEditor(isManagePage);
+	}, [editorActions, isManagePage]);
 
 	useEffect(() => {
 		if (isManagePage && quizId) {
 			getQuizById(quizId)
 				.then((foundQuiz) => {
-					loadQuiz(foundQuiz.quiz);
+					editorActions.loadQuiz(foundQuiz.quiz);
 				})
 				.catch((err) => {
 					console.error(err);
 					navigate("/not-found");
 				});
 		}
-	}, [isManagePage, quizId, loadQuiz, navigate]);
+	}, [editorActions, isManagePage, quizId, navigate]);
 
 	const handleSaveQuiz = async () => {
 		const isValid = validate();
 		if (!isValid) return;
-
-		const { title, description, questions } = useQuizEditorStore.getState();
 
 		try {
 			const quizPayload = {
@@ -104,7 +95,7 @@ export default function Edit() {
 							0,
 							QUIZ_CONSTRAINTS.TITLE_MAX_LENGTH,
 						);
-						setTitle(newValue);
+						editorActions.setTitle(newValue);
 					}}
 					maxLength={QUIZ_CONSTRAINTS.TITLE_MAX_LENGTH}
 				/>
@@ -112,14 +103,14 @@ export default function Edit() {
 				<div className="font-bold m-1 text-xs sm:text-lg text-(--col-text-muted)">
 					{counter}/{QUIZ_CONSTRAINTS.TITLE_MAX_LENGTH}
 				</div>
-				<Button onClick={clearTitle}>Clear</Button>
+				<Button onClick={editorActions.clearTitle}>Clear</Button>
 			</div>
 
 			<Textarea
 				placeholder="Enter quiz description here..."
 				className={`resize-y w-full font-bold text-xs lg:text-lg ${errors.description ? "error" : ""}`}
 				value={description}
-				onChange={(event) => setDescription(event.target.value)}
+				onChange={(event) => editorActions.setDescription(event.target.value)}
 			/>
 
 			<div className="flex flex-col gap-4">
@@ -129,7 +120,7 @@ export default function Edit() {
 			</div>
 
 			<Button
-				onClick={addQuestion}
+				onClick={editorActions.addQuestion}
 				className="bg-(--col-bg-input) hover:bg-(--col-border) shadow-none"
 			>
 				Add Question

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -1,15 +1,15 @@
 import { useState } from "react";
 import { useNavigate, Link } from "react-router-dom";
-import { useAuth } from "@/features/auth/hooks/useAuth.js";
+import { useAuthActions } from "@/features/auth/hooks/useAuth.js";
 import { GoogleLogin } from "@react-oauth/google";
 import { loginUser, loginWithGoogle } from "@/features/auth/api/auth.api.js";
 import Container from "@/shared/ui/Container.jsx";
 import Input from "@/shared/ui/Input.jsx";
 import getGoogleAuthErrorMessage from "@/features/auth/libs/getGoogleAuthErrorMessage.js";
-import { useToastStore } from "@/shared/ui/toast/toastStore.js";
+import { useToastActions } from "@/shared/ui/toast/toastStore.js";
 
 export default function Login() {
-	const addToast = useToastStore((state) => state.addToast);
+	const { addToast } = useToastActions();
 
 	const [formData, setFormData] = useState({
 		email: "",
@@ -20,7 +20,7 @@ export default function Login() {
 	const [isLoading, setIsLoading] = useState(false);
 
 	const navigate = useNavigate();
-	const login = useAuth((state) => state.login);
+	const { login } = useAuthActions();
 
 	const handleChange = (e) => {
 		setFormData({ ...formData, [e.target.name]: e.target.value });

--- a/src/pages/MyQuizzes.jsx
+++ b/src/pages/MyQuizzes.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, useMemo } from "react";
 import { getQuizzes } from "@/features/quizzes/api/quizzes.api.js";
-import { useAuth } from "@/features/auth/hooks/useAuth.js";
+import { useAuthUserState } from "@/features/auth/hooks/useAuth.js";
 import { useDebounce } from "@/shared/hooks/useDebounce.js";
 import Grid from "@/widgets/quiz-grid/ui/Grid.jsx";
 import ModalDescription from "@/features/quizzes/components/modals/ModalDescription.jsx";
@@ -9,13 +9,13 @@ import { useNavigate } from "react-router-dom";
 import { API_CONFIG } from "@/shared/config/config.js";
 import { getPaginationRange } from "@/shared/libs/pagination.js";
 import { useInfiniteList } from "@/shared/hooks/useInfiniteList.js";
-import { useToastStore } from "@/shared/ui/toast/toastStore.js";
+import { useToastActions } from "@/shared/ui/toast/toastStore.js";
 
 const ITEMS_PER_PAGE = API_CONFIG.ITEMS_PER_PAGE_QUIZZES;
 const ITEMS_PER_PAGE_FIRST = API_CONFIG.ITEMS_PER_PAGE_QUIZZES_AUTH;
 
 export default function MyQuizzes() {
-	const user = useAuth((state) => state.user);
+	const { user } = useAuthUserState();
 	const navigate = useNavigate();
 
 	const [selectedQuiz, setSelectedQuiz] = useState(null);
@@ -25,7 +25,7 @@ export default function MyQuizzes() {
 
 	const [sortOption, setSortOption] = useState("newest");
 
-	const addToast = useToastStore((state) => state.addToast);
+	const { addToast } = useToastActions();
 
 	useEffect(() => {
 		if (!user) {

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -1,6 +1,15 @@
 import { useNavigate } from "react-router-dom";
-import { useAuth } from "@/features/auth/hooks/useAuth.js";
-import { useProfilePageStore } from "@/features/profile/stores/profilePageStore.js";
+import {
+	useAuthActions,
+	useAuthUserState,
+	useAuthSessionState,
+} from "@/features/auth/hooks/useAuth.js";
+import {
+	useProfilePageActions as useProfilePageStoreActions,
+	useProfilePageIdentityState,
+	useProfilePageModalState,
+	useProfilePageStatusState,
+} from "@/features/profile/stores/profilePageStore.js";
 import useProfilePageActions from "@/features/profile/hooks/useProfilePageActions.js";
 
 import Container from "@/shared/ui/Container.jsx";
@@ -9,26 +18,20 @@ import ModalConfirm from "@/shared/ui/ModalConfirm.jsx";
 import ModalChangePassword from "@/features/profile/components/ModalChangePassword.jsx";
 import Button from "@/shared/ui/Button.jsx";
 
-import { useToastStore } from "@/shared/ui/toast/toastStore.js";
+import { useToastActions } from "@/shared/ui/toast/toastStore.js";
 
 export default function Profile() {
 	const navigate = useNavigate();
-	const authUser = useAuth((state) => state.user);
-	const logout = useAuth((state) => state.logout);
-	const login = useAuth((state) => state.login);
-	const token = useAuth((state) => state.token);
-	const isSessionChecking = useAuth((state) => state.isSessionChecking);
-	const user = useProfilePageStore((state) => state.user);
-	const isLoading = useProfilePageStore((state) => state.isLoading);
-	const isSaving = useProfilePageStore((state) => state.isSaving);
-	const isDeleteModalOpen = useProfilePageStore((state) => state.isDeleteModalOpen);
-	const isPasswordModalOpen = useProfilePageStore((state) => state.isPasswordModalOpen);
-	const openDeleteModal = useProfilePageStore((state) => state.openDeleteModal);
-	const closeDeleteModal = useProfilePageStore((state) => state.closeDeleteModal);
-	const openPasswordModal = useProfilePageStore((state) => state.openPasswordModal);
-	const closePasswordModal = useProfilePageStore((state) => state.closePasswordModal);
+	const { user: authUser } = useAuthUserState();
+	const { logout, login } = useAuthActions();
+	const { token, isSessionChecking } = useAuthSessionState();
+	const { user } = useProfilePageIdentityState();
+	const { isLoading, isSaving } = useProfilePageStatusState();
+	const { isDeleteModalOpen, isPasswordModalOpen } = useProfilePageModalState();
+	const { openDeleteModal, closeDeleteModal, openPasswordModal, closePasswordModal } =
+		useProfilePageStoreActions();
 
-	const addToast = useToastStore((state) => state.addToast);
+	const { addToast } = useToastActions();
 	const { saveProfile, removeAccount } = useProfilePageActions({
 		navigate,
 		login,

--- a/src/pages/Quiz.jsx
+++ b/src/pages/Quiz.jsx
@@ -6,33 +6,34 @@ import {
 } from "@/features/results/api/results.api.js";
 import { getQuizById } from "@/features/quizzes/api/quizzes.api.js";
 import { useEffect } from "react";
-import { useAuth } from "@/features/auth/hooks/useAuth.js";
+import { useAuthUserState } from "@/features/auth/hooks/useAuth.js";
 import Question from "@/features/quizzes/components/quiz/Question.jsx";
-import { useQuizSessionStore } from "@/features/quizzes/stores/quizSessionStore.js";
+import {
+	useQuizSessionActions,
+	useQuizSessionViewState,
+} from "@/features/quizzes/stores/quizSessionStore.js";
 import Button from "@/shared/ui/Button.jsx";
 import Container from "@/shared/ui/Container.jsx";
 import ModalConfirm from "@/shared/ui/ModalConfirm.jsx";
-import { useToastStore } from "@/shared/ui/toast/toastStore.js";
+import { useToastActions } from "@/shared/ui/toast/toastStore.js";
 
 export default function Quiz() {
 	const navigate = useNavigate();
 	const { quizId, resultIdParam } = useParams();
-	const user = useAuth((state) => state.user);
-	const loading = useQuizSessionStore((state) => state.loading);
-	const quizData = useQuizSessionStore((state) => state.quizData);
-	const resultData = useQuizSessionStore((state) => state.resultData);
-	const answers = useQuizSessionStore((state) => state.answers);
-	const alertInfo = useQuizSessionStore((state) => state.alertInfo);
-	const loadQuizForPlay = useQuizSessionStore((state) => state.loadQuizForPlay);
-	const loadResultForView = useQuizSessionStore((state) => state.loadResultForView);
-	const setValidationErrors = useQuizSessionStore((state) => state.setValidationErrors);
-	const setGuestResult = useQuizSessionStore((state) => state.setGuestResult);
-	const setAlertInfo = useQuizSessionStore((state) => state.setAlertInfo);
-	const closeAlert = useQuizSessionStore((state) => state.closeAlert);
-	const setLoading = useQuizSessionStore((state) => state.setLoading);
-	const resetSession = useQuizSessionStore((state) => state.resetSession);
+	const { user } = useAuthUserState();
+	const { loading, quizData, resultData, answers, alertInfo } = useQuizSessionViewState();
+	const {
+		loadQuizForPlay,
+		loadResultForView,
+		setValidationErrors,
+		setGuestResult,
+		setAlertInfo,
+		closeAlert,
+		setLoading,
+		resetSession,
+	} = useQuizSessionActions();
 
-	const addToast = useToastStore((state) => state.addToast);
+	const { addToast } = useToastActions();
 
 	const isResultView = Boolean(resultIdParam) || Boolean(resultData);
 

--- a/src/pages/Quizzes.jsx
+++ b/src/pages/Quizzes.jsx
@@ -1,6 +1,6 @@
 import { useState, useCallback } from "react";
 import { getQuizzes } from "@/features/quizzes/api/quizzes.api.js";
-import { useAuth } from "@/features/auth/hooks/useAuth.js";
+import { useAuthUserState } from "@/features/auth/hooks/useAuth.js";
 import { useDebounce } from "@/shared/hooks/useDebounce.js";
 import Grid from "@/widgets/quiz-grid/ui/Grid.jsx";
 import ModalDescription from "@/features/quizzes/components/modals/ModalDescription.jsx";
@@ -8,13 +8,13 @@ import ToolBar from "@/widgets/quiz-toolbar/ui/ToolBar.jsx";
 import { API_CONFIG } from "@/shared/config/config.js";
 import { getPaginationRange } from "@/shared/libs/pagination.js";
 import { useInfiniteList } from "@/shared/hooks/useInfiniteList.js";
-import { useToastStore } from "@/shared/ui/toast/toastStore.js";
+import { useToastActions } from "@/shared/ui/toast/toastStore.js";
 
 const ITEMS_PER_PAGE = API_CONFIG.ITEMS_PER_PAGE_QUIZZES;
 const ITEMS_PER_PAGE_AUTH = API_CONFIG.ITEMS_PER_PAGE_QUIZZES_AUTH;
 
 export default function Quizzes() {
-	const user = useAuth((state) => state.user);
+	const { user } = useAuthUserState();
 	const [selectedQuiz, setSelectedQuiz] = useState(null);
 
 	const [searchQuery, setSearchQuery] = useState("");
@@ -22,7 +22,7 @@ export default function Quizzes() {
 
 	const [sortOption, setSortOption] = useState("newest");
 
-	const addToast = useToastStore((state) => state.addToast);
+	const { addToast } = useToastActions();
 
 	const loadData = useCallback(
 		async ({ pageToLoad }) => {

--- a/src/pages/Register.jsx
+++ b/src/pages/Register.jsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { useNavigate, Link } from "react-router-dom";
-import { useAuth } from "@/features/auth/hooks/useAuth.js";
+import { useAuthActions } from "@/features/auth/hooks/useAuth.js";
 import { GoogleLogin } from "@react-oauth/google";
 import {
 	registerUser,
@@ -12,17 +12,17 @@ import Input from "@/shared/ui/Input.jsx";
 import Button from "@/shared/ui/Button.jsx";
 import { QUIZ_CONSTRAINTS } from "@/shared/config/config.js";
 import getGoogleAuthErrorMessage from "@/features/auth/libs/getGoogleAuthErrorMessage.js";
-import { useToastStore } from "@/shared/ui/toast/toastStore.js";
+import { useToastActions } from "@/shared/ui/toast/toastStore.js";
 
 export default function Register() {
 	const navigate = useNavigate();
-	const login = useAuth((state) => state.login);
+	const { login } = useAuthActions();
 
 	const [step, setStep] = useState(1);
 	const [isLoading, setIsLoading] = useState(false);
 	const [error, setError] = useState("");
 
-	const addToast = useToastStore((state) => state.addToast);
+	const { addToast } = useToastActions();
 
 	const [formData, setFormData] = useState({
 		email: "",

--- a/src/pages/Results.jsx
+++ b/src/pages/Results.jsx
@@ -1,7 +1,7 @@
 import { useState, useCallback } from "react";
 import { useNavigate, Link } from "react-router-dom";
 import { getResults } from "@/features/results/api/results.api.js";
-import { useAuth } from "@/features/auth/hooks/useAuth.js";
+import { useAuthUserState } from "@/features/auth/hooks/useAuth.js";
 import { useDebounce } from "@/shared/hooks/useDebounce.js";
 import Grid from "@/widgets/quiz-grid/ui/Grid.jsx";
 import ToolBar from "@/widgets/quiz-toolbar/ui/ToolBar.jsx";
@@ -13,7 +13,7 @@ const ITEMS_PER_PAGE = API_CONFIG.ITEMS_PER_PAGE_RESULTS;
 
 export default function Results() {
 	const navigate = useNavigate();
-	const user = useAuth((state) => state.user);
+	const { user } = useAuthUserState();
 
 	const [searchQuery, setSearchQuery] = useState("");
 	const debouncedQuery = useDebounce(searchQuery, 500);
@@ -73,22 +73,22 @@ export default function Results() {
 
 	return (
 		<div className="flex flex-col items-center justify-between gap-3">
-				<ToolBar
-					search={{ value: searchQuery, onChange: setSearchQuery }}
-					sort={{ value: sortOption, onChange: setSortOption }}
-					placeholder="Search for results..."
-				/>
-				<Grid
-					items={items}
-					loading={loading}
-					hasMore={hasMore}
-					onLoadMore={handleLoadMore}
-					isLoadingMore={isLoadingMore}
-					showAddButton={false}
-					isResultsPage={true}
-					onCardClick={(item) => navigate(`/result/${item.quizId}/${item._id}`)}
-					emptyMessage={emptyMessage}
-				/>
-			</div>
+			<ToolBar
+				search={{ value: searchQuery, onChange: setSearchQuery }}
+				sort={{ value: sortOption, onChange: setSortOption }}
+				placeholder="Search for results..."
+			/>
+			<Grid
+				items={items}
+				loading={loading}
+				hasMore={hasMore}
+				onLoadMore={handleLoadMore}
+				isLoadingMore={isLoadingMore}
+				showAddButton={false}
+				isResultsPage={true}
+				onCardClick={(item) => navigate(`/result/${item.quizId}/${item._id}`)}
+				emptyMessage={emptyMessage}
+			/>
+		</div>
 	);
 }

--- a/src/shared/hooks/useAutoReload.js
+++ b/src/shared/hooks/useAutoReload.js
@@ -1,13 +1,13 @@
 import { useEffect, useRef } from "react";
 import { useLocation } from "react-router-dom";
-import { useAuth } from "@/features/auth/hooks/useAuth.js";
+import { useAuthActions, useAuthSessionState } from "@/features/auth/hooks/useAuth.js";
 import { AUTO_RELOAD_CONFIG } from "@/shared/config/config.js";
 
 export default function useAutoReload(onRefresh, timeoutMs = AUTO_RELOAD_CONFIG.TIME_OUT_MS) {
 	const lastLeaveTime = useRef(null);
 	const location = useLocation();
-	const token = useAuth((state) => state.token);
-	const checkSession = useAuth((state) => state.checkSession);
+	const { token } = useAuthSessionState();
+	const { checkSession } = useAuthActions();
 
 	useEffect(() => {
 		const handleVisibilityChange = () => {

--- a/src/shared/ui/toast/Toast.jsx
+++ b/src/shared/ui/toast/Toast.jsx
@@ -1,4 +1,4 @@
-import { useToastStore } from "./toastStore.js";
+import { useToastActions } from "./toastStore.js";
 
 import { TOAST_CONFIG } from "@/shared/config/config.js";
 
@@ -7,7 +7,7 @@ import systemIcon from "@/shared/assets/logo-icon.png";
 const { TOAST_LIFETIME, TOAST_ANIM_TIME } = TOAST_CONFIG;
 
 export default function Toast({ id, message, image = systemIcon, isExiting }) {
-	const dismissToast = useToastStore((state) => state.dismissToast);
+	const { dismissToast } = useToastActions();
 
 	const styles = {
 		"--toast-lifetime": `${TOAST_LIFETIME}ms`,

--- a/src/shared/ui/toast/ToastContainer.jsx
+++ b/src/shared/ui/toast/ToastContainer.jsx
@@ -1,8 +1,8 @@
-import { useToastStore } from "./toastStore.js";
+import { useToastListState } from "./toastStore.js";
 import Toast from "./Toast.jsx";
 
 export default function ToastContainer() {
-	const toasts = useToastStore((state) => state.toasts);
+	const { toasts } = useToastListState();
 
 	if (toasts.length === 0) return null;
 

--- a/src/shared/ui/toast/toastStore.js
+++ b/src/shared/ui/toast/toastStore.js
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { useShallow } from "zustand/react/shallow";
 import { Queue } from "@/shared/libs/queue.js";
 
 import { TOAST_CONFIG } from "@/shared/config/config.js";
@@ -9,55 +10,65 @@ const timers = new Map();
 
 export const useToastStore = create((set, get) => ({
 	toasts: [],
+	actions: {
+		addToast: (message, image) => {
+			const id = crypto.randomUUID();
+			const newToast = { id, message, image };
 
-	addToast: (message, image) => {
-		const id = crypto.randomUUID();
-		const newToast = { id, message, image };
+			queue.enqueue(newToast);
 
-		queue.enqueue(newToast);
+			const activeToasts = queue.items.filter((toast) => !toast.isExiting);
 
-		const activeToasts = queue.items.filter((toast) => !toast.isExiting);
-
-		if (activeToasts.length > MAX_TOASTS) {
-			const oldestActive = activeToasts[0];
-			if (oldestActive) {
-				get().dismissToast(oldestActive.id);
+			if (activeToasts.length > MAX_TOASTS) {
+				const oldestActive = activeToasts[0];
+				if (oldestActive) {
+					get().actions.dismissToast(oldestActive.id);
+				}
 			}
-		}
 
-		set({ toasts: queue.toArray() });
+			set({ toasts: queue.toArray() });
 
-		const timerId = setTimeout(() => {
-			get().dismissToast(id);
-		}, TOAST_LIFETIME);
+			const timerId = setTimeout(() => {
+				get().actions.dismissToast(id);
+			}, TOAST_LIFETIME);
 
-		timers.set(id, timerId);
-	},
+			timers.set(id, timerId);
+		},
 
-	dismissToast: (id) => {
-		const item = queue.items.find((toast) => toast.id === id);
-		if (!item || item.isExiting) return;
+		dismissToast: (id) => {
+			const item = queue.items.find((toast) => toast.id === id);
+			if (!item || item.isExiting) return;
 
-		item.isExiting = true;
-		set({ toasts: queue.toArray() });
+			item.isExiting = true;
+			set({ toasts: queue.toArray() });
 
-		if (timers.has(id)) clearTimeout(timers.get(id));
+			if (timers.has(id)) clearTimeout(timers.get(id));
 
-		const animTimerId = setTimeout(() => {
-			get().removeToast(id);
-		}, TOAST_ANIM_TIME);
+			const animTimerId = setTimeout(() => {
+				get().actions.removeToast(id);
+			}, TOAST_ANIM_TIME);
 
-		timers.set(id, animTimerId);
-	},
+			timers.set(id, animTimerId);
+		},
 
-	removeToast: (id) => {
-		if (timers.has(id)) {
-			clearTimeout(timers.get(id));
-			timers.delete(id);
-		}
+		removeToast: (id) => {
+			if (timers.has(id)) {
+				clearTimeout(timers.get(id));
+				timers.delete(id);
+			}
 
-		queue.items = queue.items.filter((toast) => toast.id !== id);
+			queue.items = queue.items.filter((toast) => toast.id !== id);
 
-		set({ toasts: queue.toArray() });
+			set({ toasts: queue.toArray() });
+		},
 	},
 }));
+
+export const useToastListState = () =>
+	useToastStore(
+		useShallow((state) => ({
+			toasts: state.toasts,
+		})),
+	);
+
+export const useToastActions = () => useToastStore.getState().actions;

--- a/src/widgets/header/ui/Header.jsx
+++ b/src/widgets/header/ui/Header.jsx
@@ -1,13 +1,13 @@
 import logoImage from "@/shared/assets/logo-icon.png";
 import { Link, useNavigate } from "react-router-dom";
-import { useAuth } from "@/features/auth/hooks/useAuth.js";
+import { useAuthActions, useAuthUserState } from "@/features/auth/hooks/useAuth.js";
 import { useState } from "react";
 import ModalConfirm from "@/shared/ui/ModalConfirm.jsx";
 import Avatar from "@/shared/ui/Avatar.jsx";
 
 export default function Header() {
-	const user = useAuth((state) => state.user);
-	const logout = useAuth((state) => state.logout);
+	const { user } = useAuthUserState();
+	const { logout } = useAuthActions();
 	const navigate = useNavigate();
 
 	const [isLogoutModalOpen, setIsLogoutModalOpen] = useState(false);


### PR DESCRIPTION
This PR restructures Zustand usage across the app to separate reactive state from mutations, add grouped shallow selector hooks, and move action access to dedicated non-subscribing hooks. It also updates all consumers to use the new pattern and stabilizes the Edit page flow to avoid render loops.